### PR TITLE
Fix: Missing cleanup function in useEffect for banner deleted count p…

### DIFF
--- a/frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/src/pages/AdminDashboard.jsx
@@ -663,9 +663,11 @@ export const AdminDashboard = () => {
   // When on Bookings tab, fetch deleted count so we can show "Restore all" banner if any are in Deleted
   useEffect(() => {
     if (activeTab !== 'bookings') return;
+    let cancelled = false;
     axios.get(`${API}/admin/bookings/retention-counts`, getAuthHeaders()).then((r) => {
-      if (r.data && typeof r.data.deleted === 'number') setDeletedCountForBanner(r.data.deleted);
-    }).catch(() => setDeletedCountForBanner(null));
+      if (!cancelled && r.data && typeof r.data.deleted === 'number') setDeletedCountForBanner(r.data.deleted);
+    }).catch(() => { if (!cancelled) setDeletedCountForBanner(null); });
+    return () => { cancelled = true; };
   }, [activeTab]);
 
   const getAuthHeaders = () => {


### PR DESCRIPTION
…revents stale update prevention, allowing state updates after component unmount or effect cancellation

This commit fixes the issue reported at frontend/src/pages/AdminDashboard.jsx:665

**Bug Explanation:**
The useEffect hook at lines 664-671 in AdminDashboard.jsx was making an axios API call to fetch deleted count for the banner. While it had initialized a `cancelled` flag and checked it in the promise callbacks, it was missing the essential cleanup function that should return `() => { cancelled = true; }`. Without this cleanup function, when the component unmounts or when the activeTab dependency changes, the cancelled flag never gets set to true. This means if an API response arrives after the effect should have been cancelled, the promise callback will still execute its state update, causing:
1. Memory leak warnings in React strict mode
2. Stale data displayed if user rapidly switches tabs
3. State updates on unmounted components

The issue manifests when:
- User is on the Bookings tab and API request is in flight
- User rapidly switches to another tab before the response arrives
- The API response arrives and sets state even though the component shouldn't be displaying that data

**Fix Applied:**
Added the cleanup function `return () => { cancelled = true; };` before the closing brace of the useEffect. This follows the established pattern already used in the earlier useEffect (lines 650-661) that fetches retention counts. The fix ensures:
1. When the effect re-runs or component unmounts, the cleanup function is called
2. The cancelled flag is set to true
3. All subsequent promise callbacks check `if (!cancelled)` before updating state
4. Stale updates are prevented, fixing both the memory leak and the stale data issue