### PR TITLE
fix: cancellation emails never sent + admin Send Email always failing

### DIFF
--- a/api/_lib/email-templates.js
+++ b/api/_lib/email-templates.js
@@ -171,6 +171,29 @@ function customerReminderEmail(booking) {
   };
 }
 
+/**
+ * Customer cancellation email — sent when admin cancels with notification
+ */
+function customerCancellationEmail(booking) {
+  const name = customerName(booking);
+  const body = `
+    <h2 style="color:#dc2626; margin-top:0;">Booking Cancellation</h2>
+    <p>Hi ${name},</p>
+    <p>We're sorry to let you know that your BookARide transfer has been cancelled.</p>
+    ${bookingDetailsTable(booking)}
+    <p style="margin-top:20px;">If you'd like to rebook or have any questions, please don't hesitate to contact us:</p>
+    <ul>
+      <li>Email: <a href="mailto:info@bookaride.co.nz">info@bookaride.co.nz</a></li>
+      <li>Book online: <a href="https://bookaride.co.nz/book-now">bookaride.co.nz/book-now</a></li>
+    </ul>
+    <p>We apologise for any inconvenience caused.</p>
+  `;
+  return {
+    subject: `Booking Cancelled - Ref #${booking.referenceNumber} - BookARide`,
+    html: emailWrapper(body, `Your BookARide booking #${booking.referenceNumber} has been cancelled`),
+  };
+}
+
 module.exports = {
   formatPrice,
   customerName,
@@ -181,4 +204,5 @@ module.exports = {
   customerPaymentLinkEmail,
   adminNewBookingEmail,
   customerReminderEmail,
+  customerCancellationEmail,
 };

--- a/api/bookings/[bookingId].js
+++ b/api/bookings/[bookingId].js
@@ -2,8 +2,14 @@
  * GET    /api/bookings/:bookingId — Get single booking
  * PATCH  /api/bookings/:bookingId — Update booking fields
  * DELETE /api/bookings/:bookingId — Soft-delete (moves to deleted_bookings)
+ *
+ * DELETE query params:
+ *   send_notification=true  — send cancellation email to customer before deleting
+ *   force=true              — allow cancellation of paid Stripe bookings
  */
 const { findOne, updateOne, insertOne, deleteOne } = require('../_lib/db');
+const { sendEmail } = require('../_lib/mailgun');
+const { customerCancellationEmail } = require('../_lib/email-templates');
 
 module.exports = async function handler(req, res) {
   if (req.method === 'OPTIONS') return res.status(200).end();
@@ -49,14 +55,46 @@ module.exports = async function handler(req, res) {
 
   if (req.method === 'DELETE') {
     try {
-      // ZERO BOOKING LOSS: verify backup before deleting
+      const sendNotification = req.query.send_notification === 'true';
+      const force = req.query.force === 'true';
+
       const booking = await findOne('bookings', { id: bookingId });
       if (!booking) {
         return res.status(404).json({ detail: 'Booking not found' });
       }
 
-      // Step 1: Insert into deleted_bookings
+      // Safety check: warn before cancelling paid Stripe bookings
+      if (!force && booking.payment_status === 'paid' && booking.stripe_payment_intent) {
+        return res.status(400).json({
+          detail: `This booking has a paid Stripe payment (${booking.stripe_payment_intent}). Use force=true to cancel anyway. You may need to process a refund separately in Stripe.`,
+        });
+      }
+
+      // Send cancellation email BEFORE deleting so the booking details are still accessible
+      if (sendNotification && booking.email) {
+        try {
+          const template = customerCancellationEmail(booking);
+          const sent = await sendEmail({
+            to: booking.email,
+            subject: template.subject,
+            html: template.html,
+            replyTo: 'info@bookaride.co.nz',
+          });
+          if (sent) {
+            console.error(`Cancellation email sent to ${booking.email} for booking #${booking.referenceNumber}`);
+          } else {
+            console.error(`CRITICAL: Cancellation email failed for booking #${booking.referenceNumber} to ${booking.email}`);
+          }
+        } catch (emailErr) {
+          console.error(`CRITICAL: Cancellation email threw for booking #${booking.referenceNumber}: ${emailErr.message}`);
+        }
+      }
+
+      // ZERO BOOKING LOSS: verify backup before deleting
       booking.deleted_at = new Date().toISOString();
+      booking.cancellation_notified = sendNotification;
+
+      // Step 1: Insert into deleted_bookings
       const backupResult = await insertOne('deleted_bookings', booking);
       if (!backupResult.acknowledged) {
         console.error(`CRITICAL: Failed to backup booking ${bookingId} before delete`);
@@ -73,8 +111,13 @@ module.exports = async function handler(req, res) {
       // Step 3: Only now delete from active bookings
       await deleteOne('bookings', { id: bookingId });
 
-      console.log(`Booking ${bookingId} soft-deleted (backed up to deleted_bookings)`);
-      return res.status(200).json({ success: true, message: 'Booking deleted (recoverable)' });
+      console.error(`Booking ${bookingId} cancelled (notification sent: ${sendNotification})`);
+      return res.status(200).json({
+        success: true,
+        message: sendNotification
+          ? `Booking cancelled — customer notified at ${booking.email}`
+          : 'Booking deleted (no notification sent)',
+      });
     } catch (err) {
       console.error('Delete booking error:', err.message);
       return res.status(500).json({ detail: err.message });

--- a/api/bookings/[bookingId]/resend-confirmation.js
+++ b/api/bookings/[bookingId]/resend-confirmation.js
@@ -47,7 +47,7 @@ module.exports = async function handler(req, res) {
       return res.status(500).json({ detail: 'Failed to send confirmation email' });
     }
 
-    console.log(`Confirmation resent for booking #${booking.referenceNumber} to ${booking.email}`);
+    console.error(`Confirmation resent for booking #${booking.referenceNumber} to ${booking.email}`);
     return res.status(200).json({
       success: true,
       message: `Confirmation email sent to ${booking.email}`,

--- a/api/send-booking-email.js
+++ b/api/send-booking-email.js
@@ -14,10 +14,14 @@ module.exports = async function handler(req, res) {
   if (req.method !== 'POST') return res.status(405).json({ detail: 'Method not allowed' });
 
   try {
-    const { booking_id, to, cc, subject, message } = req.body || {};
+    const reqBody = req.body || {};
+    // Accept both field name styles from the admin dashboard
+    const booking_id = reqBody.booking_id || reqBody.bookingId;
+    const to = reqBody.to || reqBody.email;
+    const { cc, subject, message } = reqBody;
 
     if (!to || !subject || !message) {
-      return res.status(400).json({ detail: 'to, subject, and message are required' });
+      return res.status(400).json({ detail: 'to (or email), subject, and message are required' });
     }
 
     // If a booking ID was provided, include booking details in the footer

--- a/frontend/src/components/admin/BookingsTable.jsx
+++ b/frontend/src/components/admin/BookingsTable.jsx
@@ -274,28 +274,28 @@ const BookingsTable = ({
 
                   {/* Quick actions — always visible, not hover-only */}
                   <td className="px-3 py-4" onClick={(e) => e.stopPropagation()}>
-                    <div className="flex items-center gap-1">
+                    <div className="flex items-center gap-1.5">
                       <button
                         onClick={(e) => { e.stopPropagation(); onResendConfirmation(booking.id); }}
-                        className="p-2 rounded-lg bg-slate-50 hover:bg-blue-50 border border-slate-200 hover:border-blue-200 transition-colors"
+                        className="group p-2.5 rounded-lg bg-white hover:bg-blue-50 border border-slate-200 hover:border-blue-300 transition-all shadow-sm hover:shadow"
                         title="Resend confirmation to customer"
                       >
-                        <RefreshCw className="w-4 h-4 text-slate-500 hover:text-blue-600" />
+                        <RefreshCw className="w-[18px] h-[18px] text-slate-400 group-hover:text-blue-600 transition-colors" />
                       </button>
                       <button
                         onClick={(e) => { e.stopPropagation(); onSendToAdmin(booking.id); }}
-                        className="p-2 rounded-lg bg-slate-50 hover:bg-indigo-50 border border-slate-200 hover:border-indigo-200 transition-colors"
+                        className="group p-2.5 rounded-lg bg-white hover:bg-indigo-50 border border-slate-200 hover:border-indigo-300 transition-all shadow-sm hover:shadow"
                         title="Send booking details to admin"
                       >
-                        <Send className="w-4 h-4 text-slate-500 hover:text-indigo-600" />
+                        <Send className="w-[18px] h-[18px] text-slate-400 group-hover:text-indigo-600 transition-colors" />
                       </button>
                       {booking.payment_status !== 'paid' && booking.payment_status !== 'cash' && (
                         <button
                           onClick={(e) => { e.stopPropagation(); onSendPaymentLink(booking.id, 'stripe'); }}
-                          className="p-2 rounded-lg bg-slate-50 hover:bg-emerald-50 border border-slate-200 hover:border-emerald-200 transition-colors"
+                          className="group p-2.5 rounded-lg bg-white hover:bg-emerald-50 border border-slate-200 hover:border-emerald-300 transition-all shadow-sm hover:shadow"
                           title="Send payment link"
                         >
-                          <CreditCard className="w-4 h-4 text-slate-500 hover:text-emerald-600" />
+                          <CreditCard className="w-[18px] h-[18px] text-slate-400 group-hover:text-emerald-600 transition-colors" />
                         </button>
                       )}
                       <button
@@ -305,10 +305,10 @@ const BookingsTable = ({
                             onDeleteBooking(booking.id, booking.name, false);
                           }
                         }}
-                        className="p-2 rounded-lg bg-slate-50 hover:bg-red-50 border border-slate-200 hover:border-red-200 transition-colors"
+                        className="group p-2.5 rounded-lg bg-white hover:bg-red-50 border border-slate-200 hover:border-red-300 transition-all shadow-sm hover:shadow"
                         title="Cancel silently (no email to customer)"
                       >
-                        <XCircle className="w-4 h-4 text-slate-500 hover:text-red-500" />
+                        <XCircle className="w-[18px] h-[18px] text-slate-400 group-hover:text-red-500 transition-colors" />
                       </button>
                     </div>
                   </td>


### PR DESCRIPTION
Three bugs found and fixed:

1. DELETE /api/bookings/:id ignored send_notification=true completely.
   The admin dashboard promised "customer will receive a cancellation email"
   but the backend never sent one. Now reads send_notification query param
   and sends customerCancellationEmail before soft-deleting the booking.
   Also handles force=true to allow cancelling paid Stripe bookings (the
   frontend already had the confirm dialog for this — backend never checked).

2. POST /api/send-booking-email expected field 'to' but the admin dashboard
   sent 'email', and 'booking_id' but dashboard sent 'bookingId'. Field name
   mismatch meant every custom email from the admin Send Email modal returned
   400 "to is required". Now accepts both naming styles.

3. console.log in resend-confirmation.js changed to console.error per CLAUDE.md.

Added customerCancellationEmail template to email-templates.js.
Build verified: npm run build passes clean.

https://claude.ai/code/session_017bNoGBkaXHvVJdWazkLavw