### PR TITLE
SECURITY: Add missing JWT auth to 5 endpoints + fix cancellation crash

### DIFF
--- a/api/admin/booking-audit.js
+++ b/api/admin/booking-audit.js
@@ -6,9 +6,11 @@
  * TEMPORARY diagnostic endpoint — DELETE after investigation is complete.
  */
 const { getDb } = require('../_lib/db');
+const { verifyAdmin } = require('../_lib/auth');
 
 module.exports = async function handler(req, res) {
   if (req.method === 'OPTIONS') return res.status(200).end();
+  if (!verifyAdmin(req, res)) return;
   if (req.method !== 'GET') return res.status(405).json({ detail: 'Method not allowed' });
 
   try {

--- a/api/admin/booking-check.js
+++ b/api/admin/booking-check.js
@@ -4,9 +4,11 @@
  * DELETE THIS FILE after confirming bookings are intact.
  */
 const { getDb } = require('../_lib/db');
+const { verifyAdmin } = require('../_lib/auth');
 
 module.exports = async function handler(req, res) {
   if (req.method === 'OPTIONS') return res.status(200).end();
+  if (!verifyAdmin(req, res)) return;
   if (req.method !== 'GET') return res.status(405).json({ detail: 'Method not allowed' });
 
   try {

--- a/api/admin/send-reminders.js
+++ b/api/admin/send-reminders.js
@@ -5,6 +5,7 @@
  */
 const { findMany, updateOne } = require('../_lib/db');
 const { sendEmail } = require('../_lib/mailgun');
+const { verifyAdmin } = require('../_lib/auth');
 const { customerReminderEmail } = require('../_lib/email-templates');
 
 function getTomorrowNZDate() {
@@ -21,6 +22,7 @@ function getTomorrowNZDate() {
 
 module.exports = async function handler(req, res) {
   if (req.method === 'OPTIONS') return res.status(200).end();
+  if (!verifyAdmin(req, res)) return;
   if (req.method !== 'POST') return res.status(405).json({ detail: 'Method not allowed' });
 
   try {

--- a/api/bookings.js
+++ b/api/bookings.js
@@ -6,6 +6,7 @@
  */
 const { findOne, findMany, insertOne, updateOne, getDb } = require('./_lib/db');
 const { sendEmail } = require('./_lib/mailgun');
+const { verifyAdmin } = require('./_lib/auth');
 const {
   customerBookingReceivedEmail,
   adminNewBookingEmail,
@@ -51,6 +52,7 @@ module.exports = async function handler(req, res) {
   }
 
   if (req.method === 'GET') {
+    if (!verifyAdmin(req, res)) return;
     return listBookings(req, res);
   }
 

--- a/api/bookings/[bookingId].js
+++ b/api/bookings/[bookingId].js
@@ -8,7 +8,9 @@
  *   force=true              — allow cancellation of paid Stripe bookings
  */
 const { findOne, updateOne, insertOne, deleteOne } = require('../_lib/db');
+const { sendEmail } = require('../_lib/mailgun');
 const { verifyAdmin } = require('../_lib/auth');
+const { customerCancellationEmail } = require('../_lib/email-templates');
 
 module.exports = async function handler(req, res) {
   if (req.method === 'OPTIONS') return res.status(200).end();
@@ -112,7 +114,7 @@ module.exports = async function handler(req, res) {
       // Step 3: Only now delete from active bookings
       await deleteOne('bookings', { id: bookingId });
 
-;      console.error(`Booking ${bookingId} soft-deleted (backed up to deleted_bookings)`);
+      console.error(`Booking ${bookingId} soft-deleted (backed up to deleted_bookings)`);
       return res.status(200).json({ success: true, message: 'Booking deleted (recoverable)' });
     } catch (err) {
       console.error('Delete booking error:', err.message);

--- a/api/bookings/[bookingId]/approve.js
+++ b/api/bookings/[bookingId]/approve.js
@@ -10,6 +10,7 @@
  */
 const { findOne, updateOne } = require('../../_lib/db');
 const { sendEmail } = require('../../_lib/mailgun');
+const { verifyAdmin } = require('../../_lib/auth');
 const {
   customerBookingApprovedEmail,
   adminNewBookingEmail,
@@ -17,6 +18,7 @@ const {
 
 module.exports = async function handler(req, res) {
   if (req.method === 'OPTIONS') return res.status(200).end();
+  if (!verifyAdmin(req, res)) return;
   if (req.method !== 'POST') return res.status(405).json({ detail: 'Method not allowed' });
 
   const { bookingId } = req.query;


### PR DESCRIPTION
## Critical security fixes

5 API endpoints had no JWT authentication — publicly accessible to anyone.

| Endpoint | Issue | Fix |
|----------|-------|-----|
| `GET /api/bookings` | Leaked ALL customer names, emails, phones, booking details | Added `verifyAdmin()` |
| `POST /api/bookings/:id/approve` | Anyone could approve pending bookings | Added `verifyAdmin()` |
| `GET /api/admin/booking-audit` | Full forensic audit of all bookings exposed | Added `verifyAdmin()` |
| `GET /api/admin/booking-check` | PII search across all 3 booking collections | Added `verifyAdmin()` |
| `POST /api/admin/send-reminders` | Anyone could spam reminder emails to all customers | Added `verifyAdmin()` |

## Bug fix

`DELETE /api/bookings/:id` with `send_notification=true` would crash with `ReferenceError: customerCancellationEmail is not defined` — the function was called but never imported. Added missing `sendEmail` and `customerCancellationEmail` imports.

Also removed a stray leading semicolon that would have caused confusion in logs.

## Test plan

- [ ] `GET /api/bookings` without auth token → should return 401
- [ ] `GET /api/bookings` with valid admin token → should return bookings list
- [ ] `POST /api/bookings/:id/approve` without auth → should return 401
- [ ] Cancel a booking with "notify customer" → should not crash
- [ ] `GET /api/admin/booking-audit` without auth → should return 401

https://claude.ai/code/session_01Q9BVDjacApymdDrBF7HVTF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9BVDjacApymdDrBF7HVTF)_