### PR TITLE
Fix payment-status update + premium gold/white emails + AM/PM times

### DIFF
--- a/api/_lib/email-templates.js
+++ b/api/_lib/email-templates.js
@@ -1,7 +1,22 @@
 /**
  * Shared email templates for BookARide customer and admin emails.
  * All templates use Outlook-safe HTML table layouts.
+ *
+ * Brand palette (locked, do not change without Craig's approval):
+ *   GOLD       #D4AF37   accents, headings, button background
+ *   GOLD_DARK  #B8941F   button hover/border
+ *   INK        #1a1a1a   primary body text
+ *   PAPER      #FFFFFF   email background
+ *   CREAM      #FAF7F0   alternating row stripe / details panel
+ *   MUTE       #6b7280   secondary text
  */
+
+const GOLD       = '#D4AF37';
+const GOLD_DARK  = '#B8941F';
+const INK        = '#1a1a1a';
+const CREAM      = '#FAF7F0';
+const MUTE       = '#6b7280';
+const BORDER     = '#E5DCC3';
 
 function formatPrice(amount) {
   const n = parseFloat(amount || 0);
@@ -16,6 +31,26 @@ function customerName(booking) {
   );
 }
 
+/**
+ * Render a 24-hour time string ("14:30", "9:05", "08:00") as
+ * "14:30 (2:30 PM)" — keeps the 24-hour format for accuracy AND
+ * adds the 12-hour version because most New Zealand customers
+ * read the 12-hour format faster. If the input isn't a valid
+ * HH:MM string, falls back to whatever was passed in.
+ */
+function formatTime12(time24) {
+  if (!time24 || typeof time24 !== 'string') return time24 || 'N/A';
+  const m = time24.trim().match(/^(\d{1,2}):(\d{2})$/);
+  if (!m) return time24;
+  let h = parseInt(m[1], 10);
+  const mins = m[2];
+  if (Number.isNaN(h) || h < 0 || h > 23) return time24;
+  const period = h >= 12 ? 'PM' : 'AM';
+  let h12 = h % 12;
+  if (h12 === 0) h12 = 12;
+  return `${time24} (${h12}:${mins} ${period})`;
+}
+
 function bookingDetailsTable(booking) {
   const flightNum =
     booking.flightNumber ||
@@ -25,49 +60,93 @@ function bookingDetailsTable(booking) {
   const returnFlightNum =
     booking.returnDepartureFlightNumber || booking.returnFlightNumber || '';
 
+  const labelStyle = `padding:12px 14px; background:${CREAM}; border-bottom:1px solid ${BORDER}; font-size:13px; color:${MUTE}; letter-spacing:0.04em; text-transform:uppercase; font-weight:600; width:38%; vertical-align:top;`;
+  const valStyle   = `padding:12px 14px; border-bottom:1px solid ${BORDER}; font-size:14px; color:${INK}; vertical-align:top;`;
+  const totalLabel = `padding:14px 14px; background:${INK}; color:${GOLD}; font-size:13px; letter-spacing:0.04em; text-transform:uppercase; font-weight:700;`;
+  const totalVal   = `padding:14px 14px; background:${INK}; color:#ffffff; font-size:18px; font-weight:700;`;
+
   return `
-    <table style="width:100%; border-collapse:collapse; font-family:Arial,sans-serif; margin:20px 0;">
-      <tr><td style="padding:10px 12px; background:#f8f8f8; border-bottom:1px solid #eee;"><strong>Reference</strong></td><td style="padding:10px 12px; border-bottom:1px solid #eee;">#${booking.referenceNumber || booking.id?.slice(0, 5)}</td></tr>
-      <tr><td style="padding:10px 12px; background:#f8f8f8; border-bottom:1px solid #eee;"><strong>Pickup</strong></td><td style="padding:10px 12px; border-bottom:1px solid #eee;">${booking.pickupAddress || 'N/A'}</td></tr>
-      <tr><td style="padding:10px 12px; background:#f8f8f8; border-bottom:1px solid #eee;"><strong>Dropoff</strong></td><td style="padding:10px 12px; border-bottom:1px solid #eee;">${booking.dropoffAddress || 'N/A'}</td></tr>
-      <tr><td style="padding:10px 12px; background:#f8f8f8; border-bottom:1px solid #eee;"><strong>Date</strong></td><td style="padding:10px 12px; border-bottom:1px solid #eee;">${booking.date || 'N/A'} at ${booking.time || 'N/A'}</td></tr>
-      <tr><td style="padding:10px 12px; background:#f8f8f8; border-bottom:1px solid #eee;"><strong>Passengers</strong></td><td style="padding:10px 12px; border-bottom:1px solid #eee;">${booking.passengers || 1}</td></tr>
-      ${flightNum ? `<tr><td style="padding:10px 12px; background:#f8f8f8; border-bottom:1px solid #eee;"><strong>Flight</strong></td><td style="padding:10px 12px; border-bottom:1px solid #eee;">${flightNum}</td></tr>` : ''}
+    <table style="width:100%; border-collapse:collapse; font-family:Arial,sans-serif; margin:24px 0; border:1px solid ${BORDER}; border-radius:8px; overflow:hidden;">
+      <tr><td style="${labelStyle}">Reference</td><td style="${valStyle}"><strong style="color:${GOLD_DARK};">#${booking.referenceNumber || booking.id?.slice(0, 5)}</strong></td></tr>
+      <tr><td style="${labelStyle}">Pickup</td><td style="${valStyle}">${booking.pickupAddress || 'N/A'}</td></tr>
+      <tr><td style="${labelStyle}">Dropoff</td><td style="${valStyle}">${booking.dropoffAddress || 'N/A'}</td></tr>
+      <tr><td style="${labelStyle}">Date &amp; Time</td><td style="${valStyle}">${booking.date || 'N/A'} at <strong>${formatTime12(booking.time)}</strong></td></tr>
+      <tr><td style="${labelStyle}">Passengers</td><td style="${valStyle}">${booking.passengers || 1}</td></tr>
+      ${flightNum ? `<tr><td style="${labelStyle}">Flight</td><td style="${valStyle}">${flightNum}</td></tr>` : ''}
       ${booking.bookReturn && booking.returnDate ? `
-        <tr><td style="padding:10px 12px; background:#f3e8ff; border-bottom:1px solid #eee;"><strong>Return Date</strong></td><td style="padding:10px 12px; border-bottom:1px solid #eee;">${booking.returnDate} at ${booking.returnTime || 'N/A'}</td></tr>
-        ${returnFlightNum ? `<tr><td style="padding:10px 12px; background:#f3e8ff; border-bottom:1px solid #eee;"><strong>Return Flight</strong></td><td style="padding:10px 12px; border-bottom:1px solid #eee;">${returnFlightNum}</td></tr>` : ''}
+        <tr><td style="${labelStyle}">Return Date &amp; Time</td><td style="${valStyle}">${booking.returnDate} at <strong>${formatTime12(booking.returnTime)}</strong></td></tr>
+        ${returnFlightNum ? `<tr><td style="${labelStyle}">Return Flight</td><td style="${valStyle}">${returnFlightNum}</td></tr>` : ''}
       ` : ''}
-      <tr><td style="padding:10px 12px; background:#f8f8f8;"><strong>Total</strong></td><td style="padding:10px 12px;"><strong style="font-size:16px;">$${formatPrice(booking.pricing?.totalPrice || booking.totalPrice)} NZD</strong></td></tr>
+      <tr><td style="${totalLabel}">Total</td><td style="${totalVal}">$${formatPrice(booking.pricing?.totalPrice || booking.totalPrice)} NZD</td></tr>
     </table>
   `;
 }
 
 function emailWrapper(innerHtml, preheader = '') {
   return `
-    <div style="font-family:Arial,sans-serif; max-width:600px; margin:0 auto; padding:20px; color:#333;">
+    <div style="background:#f4f4f4; padding:24px 0; font-family:Arial,Helvetica,sans-serif;">
       ${preheader ? `<div style="display:none; max-height:0; overflow:hidden;">${preheader}</div>` : ''}
-      ${innerHtml}
-      <div style="margin-top:40px; padding-top:20px; border-top:1px solid #eee; font-size:12px; color:#888; text-align:center;">
-        <p style="margin:0;">BookARide NZ &mdash; Professional Airport Transfers</p>
-        <p style="margin:5px 0 0 0;"><a href="https://bookaride.co.nz" style="color:#888; text-decoration:none;">bookaride.co.nz</a> &middot; <a href="mailto:info@bookaride.co.nz" style="color:#888; text-decoration:none;">info@bookaride.co.nz</a></p>
-      </div>
+      <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="width:100%; max-width:600px; margin:0 auto; background:#ffffff; border-radius:12px; overflow:hidden; box-shadow:0 2px 8px rgba(0,0,0,0.04);">
+        <!-- Header band -->
+        <tr>
+          <td style="background:${INK}; padding:24px 32px; border-bottom:3px solid ${GOLD};">
+            <p style="margin:0; font-family:Georgia,serif; font-size:24px; color:${GOLD}; letter-spacing:0.04em; font-weight:700;">BookARide</p>
+            <p style="margin:4px 0 0 0; font-size:11px; color:#bdbdbd; letter-spacing:0.18em; text-transform:uppercase;">Premium Airport Transfers &middot; New Zealand</p>
+          </td>
+        </tr>
+        <!-- Body -->
+        <tr>
+          <td style="padding:32px; color:${INK}; font-size:15px; line-height:1.6;">
+            ${innerHtml}
+          </td>
+        </tr>
+        <!-- Footer band -->
+        <tr>
+          <td style="background:${CREAM}; padding:20px 32px; border-top:1px solid ${BORDER}; text-align:center; font-size:12px; color:${MUTE};">
+            <p style="margin:0 0 6px 0; color:${INK}; font-weight:600; letter-spacing:0.04em;">BookARide NZ</p>
+            <p style="margin:0;">
+              <a href="https://bookaride.co.nz" style="color:${GOLD_DARK}; text-decoration:none; font-weight:600;">bookaride.co.nz</a>
+              &nbsp;&middot;&nbsp;
+              <a href="mailto:info@bookaride.co.nz" style="color:${GOLD_DARK}; text-decoration:none; font-weight:600;">info@bookaride.co.nz</a>
+            </p>
+          </td>
+        </tr>
+      </table>
     </div>
   `;
+}
+
+function gildedHeading(text, accentColour = GOLD_DARK) {
+  return `<h2 style="margin:0 0 8px 0; font-family:Georgia,serif; font-size:24px; color:${INK}; font-weight:700; letter-spacing:0.01em;">${text}</h2><div style="height:3px; width:48px; background:${accentColour}; margin:0 0 20px 0; border-radius:2px;"></div>`;
+}
+
+function payButton(href, label) {
+  return `
+    <table width="100%" cellpadding="0" cellspacing="0" border="0" style="margin:28px 0;">
+      <tr><td align="center">
+        <a href="${href}" style="background:${GOLD}; color:${INK}; padding:16px 44px; text-decoration:none; border-radius:8px; font-weight:700; font-size:16px; letter-spacing:0.02em; display:inline-block; border:1px solid ${GOLD_DARK};">${label}</a>
+      </td></tr>
+    </table>
+  `;
+}
+
+function noReplyFooter() {
+  return `<p style="font-size:12px; color:${MUTE}; margin:28px 0 0 0; padding-top:16px; border-top:1px solid ${BORDER}; line-height:1.6;">Please do not reply to this confirmation — it is sent from an unattended address. For any questions, email <a href="mailto:info@bookaride.co.nz" style="color:${GOLD_DARK}; font-weight:600; text-decoration:none;">info@bookaride.co.nz</a>.</p>`;
 }
 
 function customerBookingReceivedEmail(booking, { requiresApproval = false } = {}) {
   const name = customerName(booking);
   const body = `
-    <h2 style="color:#1a1a1a; margin-top:0;">Thank you for your booking!</h2>
-    <p>Hi ${name},</p>
-    <p>We've received your booking request. ${
+    ${gildedHeading('Thank you for your booking')}
+    <p style="margin:0 0 14px 0;">Hi ${name},</p>
+    <p style="margin:0 0 14px 0;">We've received your booking request. ${
       requiresApproval
-        ? '<strong style="color:#d97706;">Your booking is within 24 hours and requires admin approval. You\'ll hear from us shortly.</strong>'
+        ? `<strong style="color:${GOLD_DARK};">Your booking is within 24 hours and requires admin approval — you'll hear from us shortly.</strong>`
         : 'Your booking is being processed.'
     }</p>
     ${bookingDetailsTable(booking)}
-    <p style="margin-top:20px;"><strong>Next step:</strong> Complete your payment using the link you'll receive separately, or click the pay button on your booking confirmation page.</p>
-    <p style="font-size:13px; color:#666; margin-top:30px;">Please do not reply to this confirmation — it is sent from an unattended address. For any questions, email <a href="mailto:info@bookaride.co.nz" style="color:#1a1a1a;">info@bookaride.co.nz</a>.</p>
+    <p style="margin:20px 0 0 0;"><strong style="color:${INK};">Next step:</strong> Complete your payment using the link you'll receive separately, or click the pay button on your booking confirmation page.</p>
+    ${noReplyFooter()}
   `;
   return {
     subject: `Booking Received - Ref #${booking.referenceNumber} - BookARide`,
@@ -78,13 +157,13 @@ function customerBookingReceivedEmail(booking, { requiresApproval = false } = {}
 function customerBookingConfirmedEmail(booking) {
   const name = customerName(booking);
   const body = `
-    <h2 style="color:#059669; margin-top:0;">Payment Successful!</h2>
-    <p>Hi ${name},</p>
-    <p>Your booking has been <strong>confirmed</strong> and payment received. Your driver will arrive at the scheduled time.</p>
+    ${gildedHeading('Payment Successful')}
+    <p style="margin:0 0 14px 0;">Hi ${name},</p>
+    <p style="margin:0 0 14px 0;">Your booking is <strong style="color:${GOLD_DARK};">confirmed</strong> and payment received. Your driver will arrive at the scheduled time.</p>
     ${bookingDetailsTable(booking)}
-    <p style="margin-top:20px;"><strong>Payment Status:</strong> <span style="background:#d1fae5; color:#047857; padding:4px 12px; border-radius:4px; font-weight:bold;">PAID</span></p>
-    <p style="margin-top:20px;">Thank you for choosing BookARide. We'll be in touch if anything changes.</p>
-    <p style="font-size:13px; color:#666; margin-top:30px;">Please do not reply to this confirmation — it is sent from an unattended address. For any questions, email <a href="mailto:info@bookaride.co.nz" style="color:#1a1a1a;">info@bookaride.co.nz</a>.</p>
+    <p style="margin:20px 0 0 0;"><strong style="color:${INK};">Payment Status:</strong> <span style="background:${GOLD}; color:${INK}; padding:5px 14px; border-radius:4px; font-weight:700; letter-spacing:0.06em;">PAID</span></p>
+    <p style="margin:20px 0 0 0;">Thank you for choosing BookARide. We'll be in touch if anything changes.</p>
+    ${noReplyFooter()}
   `;
   return {
     subject: `Booking Confirmed - Ref #${booking.referenceNumber} - BookARide`,
@@ -95,12 +174,13 @@ function customerBookingConfirmedEmail(booking) {
 function customerBookingApprovedEmail(booking) {
   const name = customerName(booking);
   const body = `
-    <h2 style="color:#059669; margin-top:0;">Great news — your booking is approved!</h2>
-    <p>Hi ${name},</p>
-    <p>Your BookARide transfer has been <strong>approved</strong> by our team. You're all set!</p>
+    ${gildedHeading('Your booking is approved')}
+    <p style="margin:0 0 14px 0;">Hi ${name},</p>
+    <p style="margin:0 0 14px 0;">Your BookARide transfer has been <strong style="color:${GOLD_DARK};">approved</strong> by our team. You're all set.</p>
     ${bookingDetailsTable(booking)}
-    <p style="margin-top:20px;"><strong>Next step:</strong> Please complete your payment using the link you received, or contact us at <a href="mailto:info@bookaride.co.nz">info@bookaride.co.nz</a> if you haven't received a payment link.</p>
-    <p>We'll see you soon!</p>
+    <p style="margin:20px 0 0 0;"><strong style="color:${INK};">Next step:</strong> Please complete your payment using the link you received, or contact us at <a href="mailto:info@bookaride.co.nz" style="color:${GOLD_DARK}; font-weight:600;">info@bookaride.co.nz</a> if you haven't received a payment link.</p>
+    <p style="margin:14px 0 0 0;">We'll see you soon.</p>
+    ${noReplyFooter()}
   `;
   return {
     subject: `Booking Approved - Ref #${booking.referenceNumber} - BookARide`,
@@ -112,17 +192,14 @@ function customerPaymentLinkEmail(booking, paymentUrl) {
   const name = customerName(booking);
   const amount = formatPrice(booking.pricing?.totalPrice || booking.totalPrice);
   const body = `
-    <h2 style="color:#1a1a1a; margin-top:0;">Complete Your Payment</h2>
-    <p>Hi ${name},</p>
-    <p>Please complete payment for your booking using the secure link below.</p>
+    ${gildedHeading('Complete Your Payment')}
+    <p style="margin:0 0 14px 0;">Hi ${name},</p>
+    <p style="margin:0 0 14px 0;">Please complete payment for your booking using the secure link below.</p>
     ${bookingDetailsTable(booking)}
-    <table width="100%" cellpadding="0" cellspacing="0" border="0" style="margin:30px 0;">
-      <tr><td align="center">
-        <a href="${paymentUrl}" style="background:#1a1a1a; color:#fff; padding:16px 48px; text-decoration:none; border-radius:6px; font-weight:bold; font-size:16px; display:inline-block;">Pay $${amount} NZD Securely</a>
-      </td></tr>
-    </table>
-    <p style="font-size:12px; color:#666;">Or copy this link into your browser: <a href="${paymentUrl}" style="color:#1a1a1a; word-break:break-all;">${paymentUrl}</a></p>
-    <p style="font-size:12px; color:#666; margin-top:20px;">Your payment is processed securely via Stripe. BookARide never stores your card details.</p>
+    ${payButton(paymentUrl, `Pay $${amount} NZD Securely`)}
+    <p style="font-size:12px; color:${MUTE}; margin:0;">Or copy this link into your browser:<br><a href="${paymentUrl}" style="color:${GOLD_DARK}; word-break:break-all;">${paymentUrl}</a></p>
+    <p style="font-size:12px; color:${MUTE}; margin:16px 0 0 0;">Your payment is processed securely via Stripe. BookARide never stores your card details.</p>
+    ${noReplyFooter()}
   `;
   return {
     subject: `Complete Your Payment - Ref #${booking.referenceNumber} - BookARide`,
@@ -133,13 +210,13 @@ function customerPaymentLinkEmail(booking, paymentUrl) {
 function adminNewBookingEmail(booking, { requiresApproval = false } = {}) {
   const name = customerName(booking);
   const body = `
-    <h2>New Booking #${booking.referenceNumber}</h2>
-    ${requiresApproval ? '<p style="background:#fee2e2; color:#991b1b; padding:12px; border-radius:4px; font-weight:bold;">Within 24 hours &mdash; requires manual approval</p>' : ''}
-    <p><strong>Customer:</strong> ${name}</p>
-    <p><strong>Email:</strong> ${booking.email || 'N/A'}</p>
-    <p><strong>Phone:</strong> ${booking.phone || 'N/A'}</p>
+    ${gildedHeading(`New Booking #${booking.referenceNumber}`)}
+    ${requiresApproval ? `<p style="background:#fee2e2; color:#991b1b; padding:12px 14px; border-radius:6px; font-weight:bold; margin:0 0 14px 0;">Within 24 hours — requires manual approval</p>` : ''}
+    <p style="margin:0 0 6px 0;"><strong>Customer:</strong> ${name}</p>
+    <p style="margin:0 0 6px 0;"><strong>Email:</strong> ${booking.email || 'N/A'}</p>
+    <p style="margin:0 0 6px 0;"><strong>Phone:</strong> ${booking.phone || 'N/A'}</p>
     ${bookingDetailsTable(booking)}
-    <p style="margin-top:20px;"><a href="https://bookaride.co.nz/admin/login" style="background:#1a1a1a; color:#fff; padding:10px 20px; text-decoration:none; border-radius:4px;">View in Admin Dashboard</a></p>
+    ${payButton('https://bookaride.co.nz/admin/login', 'View in Admin Dashboard')}
   `;
   return {
     subject: requiresApproval
@@ -152,17 +229,18 @@ function adminNewBookingEmail(booking, { requiresApproval = false } = {}) {
 function customerReminderEmail(booking) {
   const name = customerName(booking);
   const body = `
-    <h2 style="color:#1a1a1a; margin-top:0;">Friendly Reminder: Your Trip Tomorrow</h2>
-    <p>Hi ${name},</p>
-    <p>Just a reminder that your BookARide transfer is scheduled for <strong>tomorrow</strong>. Here are your booking details:</p>
+    ${gildedHeading('Reminder: Your Trip Tomorrow')}
+    <p style="margin:0 0 14px 0;">Hi ${name},</p>
+    <p style="margin:0 0 14px 0;">Just a reminder that your BookARide transfer is scheduled for <strong style="color:${GOLD_DARK};">tomorrow</strong>. Here are your booking details:</p>
     ${bookingDetailsTable(booking)}
-    <p style="margin-top:20px;"><strong>Please ensure:</strong></p>
-    <ul>
-      <li>You're ready at the pickup address 5 minutes before the scheduled time</li>
-      <li>Your flight number is up to date (if this is an airport transfer)</li>
-      <li>You have our contact number handy: info@bookaride.co.nz</li>
+    <p style="margin:20px 0 8px 0;"><strong style="color:${INK};">Please ensure:</strong></p>
+    <ul style="margin:0 0 14px 0; padding-left:22px; color:${INK};">
+      <li style="margin-bottom:6px;">You're ready at the pickup address 5 minutes before the scheduled time</li>
+      <li style="margin-bottom:6px;">Your flight number is up to date (if this is an airport transfer)</li>
+      <li style="margin-bottom:6px;">For anything urgent, contact <a href="mailto:info@bookaride.co.nz" style="color:${GOLD_DARK}; font-weight:600;">info@bookaride.co.nz</a></li>
     </ul>
-    <p>See you tomorrow!</p>
+    <p style="margin:0;">See you tomorrow.</p>
+    ${noReplyFooter()}
   `;
   return {
     subject: `Reminder: Your BookARide trip tomorrow - Ref #${booking.referenceNumber}`,
@@ -173,16 +251,17 @@ function customerReminderEmail(booking) {
 function customerCancellationEmail(booking) {
   const name = customerName(booking);
   const body = `
-    <h2 style="color:#dc2626; margin-top:0;">Booking Cancellation</h2>
-    <p>Hi ${name},</p>
-    <p>We're sorry to let you know that your BookARide transfer has been cancelled.</p>
+    ${gildedHeading('Booking Cancelled', '#dc2626')}
+    <p style="margin:0 0 14px 0;">Hi ${name},</p>
+    <p style="margin:0 0 14px 0;">We're sorry to let you know that your BookARide transfer has been cancelled.</p>
     ${bookingDetailsTable(booking)}
-    <p style="margin-top:20px;">If you'd like to rebook or have any questions, please don't hesitate to contact us:</p>
-    <ul>
-      <li>Email: <a href="mailto:info@bookaride.co.nz">info@bookaride.co.nz</a></li>
-      <li>Book online: <a href="https://bookaride.co.nz/book-now">bookaride.co.nz/book-now</a></li>
+    <p style="margin:20px 0 8px 0;">If you'd like to rebook or have any questions, please contact us:</p>
+    <ul style="margin:0 0 14px 0; padding-left:22px; color:${INK};">
+      <li style="margin-bottom:6px;">Email: <a href="mailto:info@bookaride.co.nz" style="color:${GOLD_DARK}; font-weight:600;">info@bookaride.co.nz</a></li>
+      <li style="margin-bottom:6px;">Book online: <a href="https://bookaride.co.nz/book-now" style="color:${GOLD_DARK}; font-weight:600;">bookaride.co.nz/book-now</a></li>
     </ul>
-    <p>We apologise for any inconvenience caused.</p>
+    <p style="margin:0;">We apologise for any inconvenience caused.</p>
+    ${noReplyFooter()}
   `;
   return {
     subject: `Booking Cancelled - Ref #${booking.referenceNumber} - BookARide`,
@@ -192,6 +271,7 @@ function customerCancellationEmail(booking) {
 
 module.exports = {
   formatPrice,
+  formatTime12,
   customerName,
   bookingDetailsTable,
   emailWrapper,

--- a/api/bookings/[bookingId]/payment-status.js
+++ b/api/bookings/[bookingId]/payment-status.js
@@ -1,0 +1,74 @@
+/**
+ * PUT /api/bookings/:bookingId/payment-status
+ *
+ * Admin updates the payment_status of a booking. Used by the
+ * BookingDetailsModal "Change → Update" control in the admin
+ * dashboard.
+ *
+ * This endpoint was missing from the Vercel API folder — the
+ * frontend has been calling it for weeks and getting a 404,
+ * which manifested as "the dropdown silently fails". Same
+ * regression pattern as the Afterpay endpoints. See CLAUDE.md.
+ *
+ * Body: { paymentStatus: 'paid' | 'cash' | 'pay-on-pickup' | 'invoiced' | 'unpaid' }
+ */
+const { findOne, updateOne } = require('../../_lib/db');
+const { verifyAdmin } = require('../../_lib/auth');
+
+const ALLOWED = new Set(['paid', 'cash', 'pay-on-pickup', 'invoiced', 'unpaid', 'pending', 'refunded']);
+
+module.exports = async function handler(req, res) {
+  if (req.method === 'OPTIONS') return res.status(200).end();
+  if (!verifyAdmin(req, res)) return;
+  if (req.method !== 'PUT' && req.method !== 'POST' && req.method !== 'PATCH') {
+    return res.status(405).json({ detail: 'Method not allowed' });
+  }
+
+  const { bookingId } = req.query;
+  if (!bookingId) return res.status(400).json({ detail: 'bookingId is required' });
+
+  const newStatus = (req.body?.paymentStatus || req.body?.payment_status || '').toLowerCase().trim();
+  if (!newStatus) {
+    return res.status(400).json({ detail: 'paymentStatus is required in request body' });
+  }
+  if (!ALLOWED.has(newStatus)) {
+    return res.status(400).json({
+      detail: `Invalid paymentStatus '${newStatus}'. Allowed: ${[...ALLOWED].join(', ')}`,
+    });
+  }
+
+  try {
+    const existing = await findOne('bookings', { id: bookingId });
+    if (!existing) return res.status(404).json({ detail: 'Booking not found' });
+
+    const update = {
+      payment_status: newStatus,
+      payment_status_updated_at: new Date().toISOString(),
+    };
+
+    // If admin marks as paid and the booking is still pending, also confirm
+    // the booking. This matches what the Stripe webhook does on a real
+    // payment so manual + automatic paths produce the same final state.
+    if (newStatus === 'paid' && existing.status !== 'completed' && existing.status !== 'cancelled') {
+      update.status = 'confirmed';
+      update.payment_confirmed_at = update.payment_confirmed_at || new Date().toISOString();
+    }
+
+    const result = await updateOne('bookings', { id: bookingId }, { $set: update });
+    if (!result || result.matched_count === 0) {
+      console.error(`CRITICAL: payment_status update for ${bookingId} matched zero rows`);
+      return res.status(500).json({ detail: 'Update did not match any booking' });
+    }
+
+    console.error(`Booking ${bookingId} payment_status -> ${newStatus} by admin`);
+    return res.status(200).json({
+      success: true,
+      bookingId,
+      payment_status: newStatus,
+      status: update.status || existing.status,
+    });
+  } catch (err) {
+    console.error(`CRITICAL: payment_status update threw for ${bookingId}: ${err.message}`);
+    return res.status(500).json({ detail: `Failed to update payment status: ${err.message}` });
+  }
+};

--- a/api/health/email-test.js
+++ b/api/health/email-test.js
@@ -79,13 +79,13 @@ module.exports = async function handler(req, res) {
   const [customerResult, adminResult] = await Promise.allSettled([
     sendEmail({
       to,
-      subject: `[BookARide email test] ${customerTpl.subject}`,
+      subject: `[TEST - CUSTOMER COPY] ${customerTpl.subject}`,
       html: customerTpl.html,
       replyTo: 'info@bookaride.co.nz',
     }),
     sendEmail({
       to: adminEmail,
-      subject: `[BookARide email test] ${adminTpl.subject}`,
+      subject: `[TEST - ADMIN COPY] ${adminTpl.subject}`,
       html: adminTpl.html,
     }),
   ]);


### PR DESCRIPTION
Three issues from Craig in one pass:

1. PAYMENT STATUS UPDATE WAS SILENTLY FAILING The frontend (BookingDetailsModal) calls PUT /api/bookings/:id/payment-status, but that endpoint never existed in the Vercel API folder — same regression pattern as the Afterpay endpoints that bit us last week. Every dropdown change returned a 404 and the UI showed a generic failure toast. Created api/bookings/[bookingId]/payment-status.js (admin auth): - Validates against an allow-list of statuses (paid / cash / pay-on-pickup / invoiced / unpaid / pending / refunded) - Sets payment_status_updated_at timestamp - When marking 'paid' on a non-completed/cancelled booking, also flips status -> 'confirmed' to match the Stripe webhook's behaviour, so manual + automatic paths produce the same final state - Logs CRITICAL on update failure so it shows up in Vercel logs

2. CONFIRMATION EMAILS NOW LOOK PREMIUM (gold + white) Replaced the generic grey email shell with a proper branded layout: - Locked palette constants at the top of email-templates.js (GOLD #D4AF37, GOLD_DARK #B8941F, INK #1a1a1a, CREAM #FAF7F0, MUTE, BORDER) - New emailWrapper renders a centred 600-px white card with black header band, gold underline accent strip, "BookARide" wordmark in Georgia serif gold, subtle cream footer band with gold links - bookingDetailsTable redone: rounded card, cream label column with uppercase tracking, ink/gold total row - Every customer template (Received, Confirmed, Approved, Payment Link, Reminder, Cancellation) now uses a shared gildedHeading helper (serif heading + 48px gold underline bar) for a consistent premium look - Stripe pay button is now gold-on-ink, the "PAID" badge is gold-on-ink, no more red/green generic boxes - Shared payButton + noReplyFooter helpers so styling cannot drift between templates

3. TIMES NOW SHOW BOTH 24-HOUR AND 12-HOUR New formatTime12() helper. "14:30" renders as "14:30 (2:30 PM)" in every booking detail table — picks up the AM/PM hint that Craig says many of his customers prefer, while still showing the 24-hour value as the primary so airport pickups stay unambiguous. Falls back to the raw input if it isn't an HH:MM string.

Plus: api/health/email-test.js now prefixes test emails with "[TEST - CUSTOMER COPY]" and "[TEST - ADMIN COPY]" so when both land in the same inbox during a diagnostic run, it's obvious which template each is — Craig was understandably confused by the admin "View in Admin Dashboard" button appearing on what he thought was a customer email (it was the admin copy).