### PR TITLE
Admin-only Pay on Pickup payment option (Craig-authorised 2026-04-28)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -719,10 +719,25 @@ session that "helpfully" added Afterpay back as a payment option,
 restored the marketing page, or re-mentioned it in AI email prompts.
 This rule exists to make that physically impossible going forward.
 
-**Stripe is the ONLY payment method on BookARide.** No Afterpay, no
-PayPal checkout flow, no Pay-On-Pickup option for the customer-facing
-form. The admin Create Booking modal also offers Stripe only — there
-is no scenario where a different payment method is the right answer.
+**Stripe is the ONLY payment method on the customer-facing site.**
+No Afterpay, no PayPal checkout flow, no Pay-On-Pickup option in
+`BookNow.jsx` — customers always pay via Stripe.
+
+**Admin-only override (Craig-authorised 2026-04-28):** the admin
+Create Booking modal (`CreateBookingModal.jsx`) offers TWO payment
+methods at the admin's discretion:
+
+1. **Stripe (default)** — payment link is emailed to the customer.
+2. **Pay on Pickup** — booking is confirmed immediately, customer
+   pays the driver in-vehicle. Used for elderly customers booked
+   over the phone, and for admin testing when Stripe checkout is
+   misbehaving.
+
+Pay-on-pickup bookings are stored with `payment_status: 'pay-on-pickup'`
+(NOT `'paid'`), `status: 'confirmed'`, and trigger the dedicated
+`customerPayOnPickupEmail` / `customerPayOnPickupSMS` templates
+(showing a "PAY ON PICKUP" amber badge, never a "PAID" gold badge).
+**This must never be added to the customer-facing booking form.**
 
 **What was removed (DO NOT RE-ADD):**
 - `frontend/src/pages/AfterpayPage.jsx` — entire marketing page

--- a/api/_lib/email-templates.js
+++ b/api/_lib/email-templates.js
@@ -171,6 +171,24 @@ function customerBookingConfirmedEmail(booking) {
   };
 }
 
+function customerPayOnPickupEmail(booking) {
+  const name = customerName(booking);
+  const body = `
+    ${gildedHeading('Booking Confirmed')}
+    <p style="margin:0 0 14px 0;">Hi ${name},</p>
+    <p style="margin:0 0 14px 0;">Your booking is <strong style="color:${GOLD_DARK};">confirmed</strong>. Your driver will arrive at the scheduled time.</p>
+    ${bookingDetailsTable(booking)}
+    <p style="margin:20px 0 0 0;"><strong style="color:${INK};">Payment:</strong> <span style="background:#fef3c7; color:#92400e; padding:5px 14px; border-radius:4px; font-weight:700; letter-spacing:0.06em;">PAY ON PICKUP</span></p>
+    <p style="margin:14px 0 0 0;">Please have payment ready when your driver arrives — cash or card accepted in-vehicle.</p>
+    <p style="margin:14px 0 0 0;">Questions? Email <a href="mailto:info@bookaride.co.nz" style="color:${GOLD_DARK}; font-weight:600;">info@bookaride.co.nz</a>.</p>
+    ${noReplyFooter()}
+  `;
+  return {
+    subject: `Booking Confirmed (Pay on Pickup) - Ref #${booking.referenceNumber} - BookARide`,
+    html: emailWrapper(body, `Your booking #${booking.referenceNumber} is confirmed — pay driver at pickup`),
+  };
+}
+
 function customerBookingApprovedEmail(booking) {
   const name = customerName(booking);
   const body = `
@@ -277,6 +295,7 @@ module.exports = {
   emailWrapper,
   customerBookingReceivedEmail,
   customerBookingConfirmedEmail,
+  customerPayOnPickupEmail,
   customerBookingApprovedEmail,
   customerPaymentLinkEmail,
   adminNewBookingEmail,

--- a/api/_lib/sms-templates.js
+++ b/api/_lib/sms-templates.js
@@ -37,7 +37,17 @@ function customerBookingConfirmedSMS(booking) {
   return `BookARide: Payment confirmed. Booking #${refOrId(booking)} on ${shortDate(booking.date)} at ${booking.time}${pickup ? ` from ${pickup}` : ''}. Help: info@bookaride.co.nz`;
 }
 
+/**
+ * Booking confirmed but customer pays the driver at pickup. Admin-only
+ * payment method — never offered customer-facing.
+ */
+function customerPayOnPickupSMS(booking) {
+  const pickup = shortAddress(booking.pickupAddress);
+  return `BookARide: Booking #${refOrId(booking)} confirmed for ${shortDate(booking.date)} at ${booking.time}${pickup ? ` from ${pickup}` : ''}. Pay driver on pickup. Help: info@bookaride.co.nz`;
+}
+
 module.exports = {
   customerBookingReceivedSMS,
   customerBookingConfirmedSMS,
+  customerPayOnPickupSMS,
 };

--- a/api/bookings/manual.js
+++ b/api/bookings/manual.js
@@ -24,12 +24,14 @@ const { sendSMS, wantsSMS, wantsEmail, isTwilioConfigured } = require('../_lib/t
 const {
   customerBookingReceivedEmail,
   customerBookingConfirmedEmail,
+  customerPayOnPickupEmail,
   customerPaymentLinkEmail,
   adminNewBookingEmail,
 } = require('../_lib/email-templates');
 const {
   customerBookingReceivedSMS,
   customerBookingConfirmedSMS,
+  customerPayOnPickupSMS,
 } = require('../_lib/sms-templates');
 
 async function maybeSendCustomerSMS(booking, smsBody, label) {
@@ -162,6 +164,17 @@ module.exports = async function handler(req, res) {
     // Payment method determines initial status
     const isPaidMethod = PAID_METHODS.has(paymentMethod);
     const isStripeMethod = STRIPE_METHODS.has(paymentMethod);
+    const isPayOnPickup = paymentMethod === 'pay-on-pickup';
+
+    // Pay-on-pickup: booking is CONFIRMED (driver will turn up) but the
+    // customer hasn't actually paid yet — they pay the driver on pickup.
+    // Use a distinct payment_status so the admin dashboard shows the
+    // real state instead of misleading "PAID".
+    const initialPaymentStatus = isPayOnPickup
+      ? 'pay-on-pickup'
+      : isPaidMethod
+        ? 'paid'
+        : 'unpaid';
 
     const bookingDoc = {
       ...body,
@@ -179,7 +192,7 @@ module.exports = async function handler(req, res) {
       totalPrice: finalTotal,
       priceOverride: override,
       payment_method: paymentMethod,
-      payment_status: isPaidMethod ? 'paid' : 'unpaid',
+      payment_status: initialPaymentStatus,
       status: isPaidMethod ? 'confirmed' : 'pending',
       createdBy: 'admin',
       createdByUsername: auth.admin.username,
@@ -347,34 +360,42 @@ module.exports = async function handler(req, res) {
         `manual booking #${refNumber} (payment link)`
       );
     } else if (isPaidMethod) {
-      // Paid on the spot — send the "confirmed + paid" email straight away.
+      // Pay-on-pickup gets its own template ("PAY ON PICKUP" badge, ask
+      // the customer to have payment ready for the driver). All other
+      // paid methods (cash, card, bank-transfer, already-paid) use the
+      // standard "Payment Successful / PAID" template.
+      const isPayOnPickup = paymentMethod === 'pay-on-pickup';
       try {
-        const confirmedTemplate = customerBookingConfirmedEmail(bookingDoc);
+        const template = isPayOnPickup
+          ? customerPayOnPickupEmail(bookingDoc)
+          : customerBookingConfirmedEmail(bookingDoc);
         const cc = body.ccEmail && emailRegex.test(body.ccEmail) ? body.ccEmail : undefined;
         const success = await sendEmail({
           to: body.email,
-          subject: confirmedTemplate.subject,
-          html: confirmedTemplate.html,
+          subject: template.subject,
+          html: template.html,
           replyTo: 'info@bookaride.co.nz',
           cc,
         });
         if (success) {
-          console.error(`Customer confirmation sent to ${body.email} for manual booking #${refNumber} (${paymentMethod})`);
+          console.error(`Customer ${isPayOnPickup ? 'pay-on-pickup' : 'confirmation'} email sent to ${body.email} for manual booking #${refNumber} (${paymentMethod})`);
           result.customer_email_sent_to = body.email;
         } else {
-          console.error(`CRITICAL: Customer confirmation returned false for manual booking #${refNumber}`);
+          console.error(`CRITICAL: Customer ${isPayOnPickup ? 'pay-on-pickup' : 'confirmation'} email returned false for manual booking #${refNumber}`);
           result.customer_email_error = 'Mailgun returned failure';
         }
       } catch (err) {
-        console.error(`Customer confirmation threw for manual booking #${refNumber}: ${err.message}`);
+        console.error(`Customer email threw for manual booking #${refNumber}: ${err.message}`);
         result.customer_email_error = err.message;
       }
 
-      // Best-effort SMS confirming the booking is paid + locked in.
+      // Best-effort SMS — pay-on-pickup gets a different body.
       await maybeSendCustomerSMS(
         bookingDoc,
-        customerBookingConfirmedSMS(bookingDoc),
-        `manual booking #${refNumber} (paid)`
+        isPayOnPickup
+          ? customerPayOnPickupSMS(bookingDoc)
+          : customerBookingConfirmedSMS(bookingDoc),
+        `manual booking #${refNumber} (${paymentMethod})`
       );
     } else {
       // Unknown payment method — still send "booking received"

--- a/frontend/src/components/admin/BookingsTable.jsx
+++ b/frontend/src/components/admin/BookingsTable.jsx
@@ -234,11 +234,14 @@ const BookingsTable = ({
                       <span className={`inline-block text-[10px] font-bold tracking-wider px-2 py-0.5 rounded-full ${
                         booking.payment_status === 'paid' ? 'bg-emerald-50 text-emerald-700' :
                         booking.payment_status === 'cash' ? 'bg-amber-50 text-amber-700' :
+                        booking.payment_status === 'pay-on-pickup' ? 'bg-amber-50 text-amber-700' :
                         'bg-slate-100 text-slate-500'
                       }`}>
-                        {(booking.payment_status || 'unpaid').toUpperCase()}
+                        {booking.payment_status === 'pay-on-pickup'
+                          ? 'PAY ON PICKUP'
+                          : (booking.payment_status || 'unpaid').toUpperCase()}
                       </span>
-                      {booking.payment_status !== 'paid' && booking.payment_status !== 'cash' && (
+                      {booking.payment_status !== 'paid' && booking.payment_status !== 'cash' && booking.payment_status !== 'pay-on-pickup' && (
                         <button
                           onClick={() => onSendPaymentLink(booking.id, 'stripe')}
                           className="block text-[11px] text-slate-400 hover:text-slate-900 transition-colors font-medium"

--- a/frontend/src/components/admin/CreateBookingModal.jsx
+++ b/frontend/src/components/admin/CreateBookingModal.jsx
@@ -261,7 +261,11 @@ const CreateBookingModal = memo(({ open, onClose, onSuccess, getAuthHeaders }) =
         returnFlightNumber: newBooking.returnFlightNumber
       }, getAuthHeaders());
 
-      toast.success(`Booking created. Stripe payment link emailed to ${newBooking.email}. Admin notified at ${response.data?.admin_email_recipient || 'bookings@bookaride.co.nz'}.`);
+      const adminRecipient = response.data?.admin_email_recipient || 'bookings@bookaride.co.nz';
+      const successMessage = newBooking.paymentMethod === 'pay-on-pickup'
+        ? `Booking confirmed. Pay-on-pickup confirmation emailed to ${newBooking.email}. Admin notified at ${adminRecipient}.`
+        : `Booking created. Stripe payment link emailed to ${newBooking.email}. Admin notified at ${adminRecipient}.`;
+      toast.success(successMessage);
       onClose();
       onSuccess?.();
     } catch (error) {
@@ -437,11 +441,22 @@ const CreateBookingModal = memo(({ open, onClose, onSuccess, getAuthHeaders }) =
               </div>
               <div>
                 <Label>Payment Method</Label>
-                <div className="mt-1 px-3 py-2 bg-gray-50 border border-gray-200 rounded-md text-sm text-gray-700">
-                  Stripe (Credit/Debit Card)
-                </div>
+                <Select
+                  value={newBooking.paymentMethod || 'stripe'}
+                  onValueChange={(value) => setNewBooking(prev => ({ ...prev, paymentMethod: value }))}
+                >
+                  <SelectTrigger className="mt-1">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="stripe">Stripe (Credit/Debit Card)</SelectItem>
+                    <SelectItem value="pay-on-pickup">Pay on Pickup (admin only)</SelectItem>
+                  </SelectContent>
+                </Select>
                 <p className="text-xs text-gold mt-1">
-                  A Stripe payment link will be emailed to the customer after the booking is created.
+                  {newBooking.paymentMethod === 'pay-on-pickup'
+                    ? 'Booking is confirmed immediately. Customer pays the driver at pickup — no Stripe link is sent.'
+                    : 'A Stripe payment link will be emailed to the customer after the booking is created.'}
                 </p>
               </div>
             </div>


### PR DESCRIPTION
Adds a payment-method dropdown to the admin Create Booking modal with Stripe (default) and Pay on Pickup. Customer-facing BookNow.jsx is unchanged — Stripe-only, as locked.

Use cases per Craig:
  - Elderly customers booked over the phone who'd rather pay the driver in cash on pickup
  - Admin testing the booking flow without depending on Stripe checkout completing (so SMS / email confirmations can be verified independently)

Backend (api/bookings/manual.js):
  - Distinct payment_status: 'pay-on-pickup' (NOT 'paid'). Admin dashboard shows the real state instead of misleading PAID.
  - Booking still goes status: 'confirmed' so it shows up in the list and the driver knows to turn up.
  - Sends new customerPayOnPickupEmail + customerPayOnPickupSMS instead of the "Payment Successful / PAID" templates.

Frontend:
  - CreateBookingModal: <Select> with Stripe + Pay on Pickup, conditional helper text, conditional success toast.
  - BookingsTable: 'PAY ON PICKUP' amber badge, hides the "Send payment link" button for these bookings (no link to send).

CLAUDE.md section 6d updated to lock in the new decision and make it explicit this must NEVER appear on the customer-facing form. The Stripe-only rule still holds for BookNow.jsx.

https://claude.ai/code/session_01SqseLQUF7jLzXfLsJdPuY4